### PR TITLE
Feature/add os based path resolving

### DIFF
--- a/bin/validate.js
+++ b/bin/validate.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const { readFileSync } = require('fs');
+const os = require('os');
 const path = require('path');
 
 const commander = require('commander');
@@ -38,7 +39,14 @@ if (commander.urlList) {
   urls = urls.concat(commander.args);
 }
 
-options.output = commander.output;
+options.output = (str => {
+  if (str[0] === '~') {
+    return str.replace('~', os.homedir());
+  }
+
+  return str;
+})(commander.output);
+
 options.summary = commander.summary;
 options.save = commander.save;
 options.rules = commander.rules && commander.rules.split(',').map(rule => rule.trim().toUpperCase()) || [];

--- a/lib/commands/validate.js
+++ b/lib/commands/validate.js
@@ -29,7 +29,7 @@ module.exports = function validate(url = '', options = {}) {
   console.time('Pageready');
 
   scraper.scrape(urlObject.href, {
-    timeout: 20000,
+    timeout: 30000,
     viewport: {
         width: 800,
         height: 600,


### PR DESCRIPTION
Added a way to resolve output paths that start with a tilde sign `~` to `os.homedir()` which is default for darwin systems, but path node package does not resolve this.